### PR TITLE
small adjustments to _sidebar.scss

### DIFF
--- a/src/assets/scss/_sidebar.scss
+++ b/src/assets/scss/_sidebar.scss
@@ -13,6 +13,7 @@
   flex-direction: column;
   align-items: center;
   height: 100%;
+  overflow: hidden;
 }
 
 .nav-item {
@@ -137,6 +138,7 @@
 
   .navbar:hover .link-text {
     display: inline;
+    white-space: nowrap;
   }
 
   .navbar:hover .logo svg {


### PR DESCRIPTION
- on desktop, on hover, .link-text class was popping out of navbar --> added overflow: hidden property to .navbar-nav selector 

- longer strings like 'sua área' was line-breaking during width transition. Added white-space: nowrap; to .navbar:hover .link-text selector