### PR TITLE
fix: Correction in the sidebar

### DIFF
--- a/src/assets/scss/_sidebar.scss
+++ b/src/assets/scss/_sidebar.scss
@@ -125,6 +125,7 @@
 
   main {
     margin: 0;
+    padding-bottom: 60px;
   }
 }
 


### PR DESCRIPTION
The sidebar on the mobile was getting over the contents when there was a sroll.

I added a property in the css, which when created scroll leaves a space regarding the height of the sidebar.

Close #72.